### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,14 +10,14 @@
 # Methods and Functions (KEYWORD2)
 ###################################
 
-tone  KEYWORD2
-noTone  KEYWORD2
-setCustomWave KEYWORD2
-getCustomSample KEYWORD2
-delay KEYWORD2
-millis  KEYWORD2
-vol KEYWORD2
-Volume  KEYWORD2
+tone	KEYWORD2
+noTone	KEYWORD2
+setCustomWave	KEYWORD2
+getCustomSample	KEYWORD2
+delay	KEYWORD2
+millis	KEYWORD2
+vol	KEYWORD2
+Volume	KEYWORD2
 
 ###################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords